### PR TITLE
Import from unittests only for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ os:
 language: d
 
 d:
- - dmd-2.082.0
+ - dmd-2.082.1
+ - dmd-2.086.1
 
 env: 
  matrix:

--- a/dub.json
+++ b/dub.json
@@ -12,9 +12,6 @@
 		"unit-threaded": "*"
 	},
 
-	"sourcePaths": ["src", "unittest"],
-	"importPaths": ["src", "unittest"],
-
 	"configurations": [
 		{
 			"name": "library"
@@ -23,7 +20,9 @@
 			"name": "unittest",
 			"targetType": "executable",
 			"preBuildCommands": ["dub run unit-threaded -c gen_ut_main -- -f build/ut.d"],
-			"mainSourceFile": "build/ut.d"
+			"mainSourceFile": "build/ut.d",
+			"sourcePaths": ["src", "unittest"],
+			"importPaths": ["src", "unittest"]
 		}
 	]
 }


### PR DESCRIPTION
@FeepingCreature is unittest/config/string.d used only by the tests? Since this module isn't namespaced (`config.string` instead of something like `boilerplate.config.string`) it can cause conflicts.
Also updates the compiler in travis.